### PR TITLE
Update Elixir version dependency and relax versioning

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Sh.Mixfile do
   def project do
     [app: :sh,
      version: @version,
-     elixir: "~> 1.0.0",
+     elixir: "~>1.0",
      description: "Run programs as functions in Elixir",
      deps: deps,
      package: package]


### PR DESCRIPTION
The Elixir version has been updated and relaxed to prevent warnings in
Elixir 1.1 and 1.1.0-dev environments.